### PR TITLE
Add git commit env to build command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "public"
-command = "hugo --gc --minify"
+command = "GIT_COMMIT_SHA=\"$(git rev-parse --verify HEAD)\" GIT_COMMIT_SHA_SHORT=\"$(git rev-parse --short HEAD)\" hugo --gc --minify"
 
 [context.production.environment]
 HUGO_VERSION = "0.57.2"
@@ -8,20 +8,20 @@ HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
 [context.split1]
-command = "hugo --gc --minify --enableGitInfo"
+command = "GIT_COMMIT_SHA=\"$(git rev-parse --verify HEAD)\" GIT_COMMIT_SHA_SHORT=\"$(git rev-parse --short HEAD)\" hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
 HUGO_VERSION = "0.57.2"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
-command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
+command = "GIT_COMMIT_SHA=\"$(git rev-parse --verify HEAD)\" GIT_COMMIT_SHA_SHORT=\"$(git rev-parse --short HEAD)\" hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
 HUGO_VERSION = "0.57.2"
 
 [context.branch-deploy]
-command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
+command = "GIT_COMMIT_SHA=\"$(git rev-parse --verify HEAD)\" GIT_COMMIT_SHA_SHORT=\"$(git rev-parse --short HEAD)\" hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
 HUGO_VERSION = "ç"


### PR DESCRIPTION
Since you're using netlify.toml to configure the build command used for compilation, you have to edit the netlify.toml instead to make it work since Netlify will prioritize configuration in netlify.toml over the settings set in Netlify dashboard.